### PR TITLE
Allows binary search even if an ascending-sorted rotating array has duplicate elements.

### DIFF
--- a/02/src/academy/pocu/comp3500samples/w02/searchrotatedarray/Program.java
+++ b/02/src/academy/pocu/comp3500samples/w02/searchrotatedarray/Program.java
@@ -33,7 +33,7 @@ public class Program {
             return mid;
         }
 
-        if (numbers[start] <= numbers[mid]) {
+        if (numbers[start] < numbers[mid]) {
             if (num >= numbers[start] && num <= numbers[mid]) {
                 return indexOfRotatedArray(numbers, start, mid - 1, num);
             }


### PR DESCRIPTION
Allows binary search even if an ascending-sorted rotating array has duplicate elements.

회전 배열이 오름차순이지만 '중복이 가능한 경우',
작거나 같다는 비교(<=)로는 값을 찾지 못하는 경우가 있습니다.
작다는 비교(<)로는 가능합니다.

기존 코드 반례:
// { 25, 32, 78, 1, 2, 4, 25, 25, [25], 25, 25, 25, 25, 25, 25, 25, 25 }
int[] numbers = new int[] { 25, 32, 78, 1, 2, 4, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25 };
indexOfRotatedArray(numbers, 0, numbers.length - 1, 78);